### PR TITLE
Fix error due to silent conversion warning

### DIFF
--- a/Source/UIMgr.cpp
+++ b/Source/UIMgr.cpp
@@ -276,7 +276,7 @@ namespace GW {
         NULL,           // disable_hooks
     };
     Vec2f UI::WindowPosition::yAxis(float multiplier) {
-        float h = Render::GetViewportHeight();
+        uint32_t h = Render::GetViewportHeight();
         Vec2f y;
         float correct;
         switch (state ^ 0x1) {
@@ -298,7 +298,7 @@ namespace GW {
         return y;
     }
     Vec2f UI::WindowPosition::xAxis(float multiplier) {
-        float w = Render::GetViewportWidth();
+        uint32_t w = Render::GetViewportWidth();
         Vec2f x;
         float correct;
         switch (state ^ 0x1) {
@@ -365,7 +365,7 @@ namespace GW {
     bool UI::SetWindowVisible(UI::WindowID window_id,bool is_visible) {
         if (!SetWindowVisible_Func || window_id >= UI::WindowID::WindowID_Count)
             return false;
-        SetWindowVisible_Func(window_id, is_visible ? 1 : 0, 0, 0);
+        SetWindowVisible_Func(window_id, is_visible ? 1u : 0u, 0, 0);
         return true;
     }
     bool UI::SetWindowPosition(UI::WindowID window_id, UI::WindowPosition* info) {


### PR DESCRIPTION
GWCA.vcxproj has /WX Treat Warnings As Error enabled so these conversions cause compiler errors.