### PR TITLE
Add Missing IDs for Despairs/DreamRiders

### DIFF
--- a/Include/GWCA/Constants/AgentIDs.h
+++ b/Include/GWCA/Constants/AgentIDs.h
@@ -246,9 +246,11 @@ namespace GW {
                 constexpr int FuryTitan = 5200;
                 constexpr int RageTitan2 = 5201;
                 constexpr int DementiaTitan2 = 5202;
+                constexpr int DespairTitan2 = 5203;
 
                 constexpr int TorturewebDryder = 5215;
                 constexpr int GreaterDreamRider = 5216;
+                constexpr int GreaterDreamRider2 = 5217;
             }
 
             namespace UW {


### PR DESCRIPTION
When spawned in the early Foundry Rooms, Dream Riders and Despair Titans have different IDs than when spawned in Room 5 or from killing other titans.